### PR TITLE
Added group feature for multiple sliders

### DIFF
--- a/app/code/community/MageProfis/Slideshow/Block/Adminhtml/Slideshow/Edit/Tab/Form.php
+++ b/app/code/community/MageProfis/Slideshow/Block/Adminhtml/Slideshow/Edit/Tab/Form.php
@@ -16,6 +16,14 @@ class MageProfis_Slideshow_Block_Adminhtml_Slideshow_Edit_Tab_Form extends Mage_
             'name'      => 'title',
         ));
 
+        $fieldset->addField('group_name', 'text', array(
+            'label'     => Mage::helper('mp_slideshow')->__('Group Name'),
+            'note'      => Mage::helper('mp_slideshow')->__('Slides with the same group name will be shown in the same slider'),
+            'class'     => 'required-entry',
+            'required'  => true,
+            'name'      => 'group_name',
+        ));
+
         if (!Mage::app()->isSingleStoreMode()) {
             $fieldset->addField('store_id', 'multiselect', array(
                 'name'      => 'store_id[]',

--- a/app/code/community/MageProfis/Slideshow/Block/Adminhtml/Slideshow/Grid.php
+++ b/app/code/community/MageProfis/Slideshow/Block/Adminhtml/Slideshow/Grid.php
@@ -60,6 +60,13 @@ class MageProfis_Slideshow_Block_Adminhtml_Slideshow_Grid extends Mage_Adminhtml
             'sortable'  => true,
         ));
 
+        $this->addColumn('group_name', array(
+            'header'    => Mage::helper('mp_slideshow')->__('Group Name'),
+            'align'     => 'left',
+            'index'     => 'group_name',
+            'sortable'  => true,
+        ));
+
         $this->addColumn('slide_url', array(
             'header'    => Mage::helper('mp_slideshow')->__('URL'),
             'align'     => 'left',
@@ -87,6 +94,7 @@ class MageProfis_Slideshow_Block_Adminhtml_Slideshow_Grid extends Mage_Adminhtml
             'header'    => Mage::helper('mp_slideshow')->__('Sort Order'),
             'align'     =>'left',
             'index'     => 'sort_order',
+            'width'     => '60px',
             'sortable'  => true,
         ));
 

--- a/app/code/community/MageProfis/Slideshow/Block/Widget/Slideshow.php
+++ b/app/code/community/MageProfis/Slideshow/Block/Widget/Slideshow.php
@@ -1,0 +1,30 @@
+<?php
+
+class MageProfis_Slideshow_Block_Widget_Slideshow
+extends Mage_Core_Block_Template
+implements Mage_Widget_Block_Interface
+{
+    protected $_template = 'mp_slideshow/widget/default.phtml';
+
+    /**
+     * Get slides for this widget, filtered by group_name
+     *
+     * @return MageProfis_Slideshow_Model_Resource_Slideshow_Collection|array
+     */
+    public function getSlides()
+    {
+        if ($this->getData('group_name') != '') {
+            $slides = Mage::getModel('mp_slideshow/slideshow')->getCollection()
+                ->addStoreFilter()
+                ->addFieldToFilter('group_name', $this->getData('group_name'))
+                ->addFieldToFilter('filename', array('neq' => ''))
+                ->addFieldToFilter('status', array('eq' => '1'))
+                ->setOrder('sort_order', 'ASC')
+            ;
+
+            return $slides;
+        }
+
+        return array();
+    }
+}

--- a/app/code/community/MageProfis/Slideshow/Helper/Data.php
+++ b/app/code/community/MageProfis/Slideshow/Helper/Data.php
@@ -134,4 +134,17 @@ class MageProfis_Slideshow_Helper_Data extends Mage_Core_Helper_Abstract
 
         return Mage::getDesign()->getSkinUrl('js/mp_slideshow/owl/init.js');
     }
+
+    /**
+     * Check if a string contains valid JSON data
+     *
+     * @param string $string Test string
+     *
+     * @return boolean
+     */
+    public function isValidJson($string)
+    {
+        json_decode($string);
+        return (json_last_error() == JSON_ERROR_NONE);
+    }
 }

--- a/app/code/community/MageProfis/Slideshow/Model/Source/Groupname.php
+++ b/app/code/community/MageProfis/Slideshow/Model/Source/Groupname.php
@@ -1,0 +1,38 @@
+<?php
+
+class MageProfis_Slideshow_Model_Source_Groupname
+{
+    /**
+     * Options getter
+     *
+     * @return array
+     */
+    public function toOptionArray()
+    {
+        $res = Mage::getResourceModel('mp_slideshow/slideshow');
+
+        $read = Mage::getModel('core/resource')->getConnection('core_read');
+        $select = $read->select()
+            ->from(array('s' => $res->getTable('slideshow')), array('group_name'))
+            ->where('status = 1')
+            ->group('group_name')
+            ->order('group_name')
+        ;
+
+        $stmt = $read->query($select);
+        $result = $stmt->fetchAll();
+
+        $options = array(array(
+            'value' => '',
+            'label' => Mage::helper('adminhtml')->__('-- Please Select --'),
+        ));
+        foreach ($result as $item) {
+            $options[] = array(
+                'value' => $item['group_name'],
+                'label' => $item['group_name'],
+            );
+        }
+
+        return $options;
+    }
+}

--- a/app/code/community/MageProfis/Slideshow/etc/widget.xml
+++ b/app/code/community/MageProfis/Slideshow/etc/widget.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<widgets>
+    <mp_slideshow type="mp_slideshow/widget_slideshow" translate="name description" module="mp_slideshow">
+        <name>MageProfis - Slideshow</name>
+        <description>Displays a slideshow</description>
+        <parameters>
+            <group_name translate="label description">
+                <visible>1</visible>
+                <label>Group Name</label>
+                <description>Group name as entered in slide</description>
+                <type>select</type>
+                <source_model>mp_slideshow/source_groupname</source_model>
+                <required>0</required>
+                <sort_order>10</sort_order>
+            </group_name>
+            <configuration translate="label description">
+                <visible>1</visible>
+                <label>Configuration</label>
+                <description><![CDATA[Specify a custom configuration as JSON string, see <a href="https://github.com/kenwheeler/slick#settings" target="_blank">this page</a> for available options.]]></description>
+                <type>textarea</type>
+                <required>0</required>
+                <sort_order>20</sort_order>
+            </configuration>
+        </parameters>
+    </mp_slideshow>
+</widgets>

--- a/app/code/community/MageProfis/Slideshow/sql/mp_slideshow_setup/upgrade-1.0.5-1.1.0.php
+++ b/app/code/community/MageProfis/Slideshow/sql/mp_slideshow_setup/upgrade-1.0.5-1.1.0.php
@@ -1,0 +1,20 @@
+<?php
+
+$installer = $this;
+/* @var $installer MageProfis_Slideshow_Model_Resource_Setup */
+
+$installer->startSetup();
+
+$connection = $installer->getConnection();
+/* @var $connection Varien_Db_Adapter_Interface */
+
+$connection->addColumn($installer->getTable('mp_slideshow/slideshow'), 'group_name', array(
+    'type'     => Varien_Db_Ddl_Table::TYPE_TEXT,
+    'length'   => 255,
+    'nullable' => true,
+    'default'  => null,
+    'comment'  => 'Group Name',
+    'after'    => 'title',
+));
+
+$installer->endSetup();

--- a/app/design/frontend/base/default/template/mp_slideshow/widget/default.phtml
+++ b/app/design/frontend/base/default/template/mp_slideshow/widget/default.phtml
@@ -1,0 +1,16 @@
+<?php $slides = $this->getSlides(); ?>
+<?php if ($slides->getSize() > 0): ?>
+    <div class="slick-slider"<?php if (Mage::helper('mp_slideshow')->isValidJson($this->getData('configuration'))): ?> data-slick='<?php echo $this->getData('configuration') ?>'<?php endif; ?>>
+        <?php foreach ($slides as $item): ?>
+            <div>
+                <?php if ($item->getSlideUrl()): ?>
+                    <a href="<?php echo $item->getSlideUrl() ?>" target="<?php echo $item->getSlideTarget() ?>">
+                <?php endif; ?>
+                <img data-lazy="<?php echo Mage::getBaseUrl(Mage_Core_Model_Store::URL_TYPE_MEDIA) . $item->getFilename(); ?>"/>
+                <?php if ($item->getSlideUrl()): ?>
+                    </a>
+                <?php endif; ?>
+            </div>
+        <?php endforeach; ?>
+    </div>
+<?php endif; ?>

--- a/app/locale/de_DE/MageProfis_Slideshow.csv
+++ b/app/locale/de_DE/MageProfis_Slideshow.csv
@@ -1,9 +1,14 @@
+"MageProfis - Slideshow","MageProfis - Slideshow"
 "Slideshow","Slideshow"
 "Slideshow Settings","Slideshow Einstellungen"
 "Slideshow Item Manager","Slideshow Elementverwaltung"
 "Manage Slideshows","Slideshows verwalten"
+"Displays a slideshow","Zeigt eine Slideshow an"
 "General","Allgemein"
 "Enable","Aktiviert"
+"Group Name","Gruppierung"
+"Group name as entered in slide","Gruppenname so wie in den Slide-Elementen angegeben"
+"Slides with the same group name will be shown in the same slider","Slides mit demselben Gruppennamen werden zusammen angezeigt"
 "Driver","JavaScript Framework"
 "Add Item","Eintrag hinzufügen"
 "Save Item","Eintrag speichern"
@@ -21,6 +26,7 @@
 "Self","Self (aktuelles Fenster)"
 "Top","Top (Elternfenster)"
 "Image File","Bilddatei"
+"Specify a custom configuration as JSON string, see <a href=""https://github.com/kenwheeler/slick#settings"" target=""_blank"">this page</a> for available options.","Geben Sie eine eigene Konfiguration als JSON-String an. <a href=""https://github.com/kenwheeler/slick#settings"" target=""_blank"">Verfügbare Optionen</a>"
 
 
 

--- a/app/locale/en_US/MageProfis_Slideshow.csv
+++ b/app/locale/en_US/MageProfis_Slideshow.csv
@@ -1,9 +1,14 @@
+"MageProfis - Slideshow","MageProfis - Slideshow"
 "Slideshow","Slideshow"
 "Slideshow Settings","Slideshow Settings"
 "Slideshow Item Manager","Slideshow Item Manager"
 "Manage Slideshows","Manage Slideshows"
+"Displays a slideshow","Displays a slideshow"
 "General","General"
 "Enable","Enable"
+"Group Name","Group Name"
+"Group name as entered in slide","Group name as entered in slide"
+"Slides with the same group name will be shown in the same slider","Slides with the same group name will be shown in the same slider"
 "Driver","JavaScript Framework"
 "Add Item","Add Item"
 "Save Item","Save Item"
@@ -21,6 +26,7 @@
 "Self","Self"
 "Top","Top"
 "Image File","Image File"
+"Specify a custom configuration as JSON string, see <a href=""https://github.com/kenwheeler/slick#settings"" target=""_blank"">this page</a> for available options.","Specify a custom configuration as JSON string, see <a href=""https://github.com/kenwheeler/slick#settings"" target=""_blank"">this page</a> for available options."
 
 
 


### PR DESCRIPTION
New database field: `group_name`, enables easy grouping of sliders in multiple slideshows. You can now have a set of slides on page A while showing a different set of slides on page B. To render a slideshow (a set of slides) you can use a widget. The widget only needs the group name. You can specify a custom configuration as JSON string that will be rendered as data-attribute. This is (currently) only supported with the Slick slider (as of Slick slider version 1.5).

Please note, that all slides are rendered on the homepage by default, even when the grouping feature is used. I figure, that if you understand what this module does and how it works, that you are able to remove the default slideshow block from the homepage and replace it with your own implementation.
